### PR TITLE
Update functions.php

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -102,10 +102,10 @@ function do_agent_details() {
     if (genesis_get_custom_field('_agent_fax') != '')
         $output .= sprintf('<p class="tel fax" itemprop="faxNumber"><span class="type">Fax</span>: <span class="value">%s</span></p>', genesis_get_custom_field('_agent_fax') );
 
-    if (genesis_get_custom_field('_agent_email') != '')
+    if (genesis_get_custom_field('_agent_email') != '') {
         $email = genesis_get_custom_field('_agent_email');
         $output .= sprintf('<p><a class="email" itemprop="email" href="mailto:%s">%s</a></p>', antispambot($email), antispambot($email) );
-
+        }
     if (genesis_get_custom_field('_agent_website') != '')
         $output .= sprintf('<p><a class="website" itemprop="url" href="http://%s">%s</a></p>', genesis_get_custom_field('_agent_website'), genesis_get_custom_field('_agent_website') );
 


### PR DESCRIPTION
I noticed line 105 of plugin's functions.php email code needs to be wrapped in brackets since it is on two lines:
as it is now:

if (genesis_get_custom_field('_agent_email') != '')
$email = genesis_get_custom_field('_agent_email');
$output .= sprintf('<p>%s</p>', antispambot($email), antispambot($email) );

as it should be:

if (genesis_get_custom_field('_agent_email') != '') {
$email = genesis_get_custom_field('_agent_email');
$output.= sprintf('<p>%s</p>', antispambot($email), antispambot($email));
}

It is throwing a PHP warning with DEBUG on.

https://wordpress.org/plugins/genesis-agent-profiles/
